### PR TITLE
部分修复windows login崩溃的问题

### DIFF
--- a/logintool/login.go
+++ b/logintool/login.go
@@ -104,6 +104,7 @@ func verify_login(auth_code string) {
 	req, _ := http.NewRequest("POST", api, data_string)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	for {
+		time.Sleep(10 * time.Second)
 		resp, err := client.Do(req)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
本地通过交叉编译进行了测试，在windows terminal中，可以在崩溃前扫出结果，并在扫描成功后不崩溃