### PR TITLE
🐞 fix: click_time param of like API

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -172,7 +172,7 @@ class BiliApi:
             "access_key": self.u.access_key,
             "actionKey": "appkey",
             "appkey": Crypto.APPKEY,
-            "click_time": int(time.time()),
+            "click_time": 1,
             "roomid": room_id,
         }
         # for _ in range(3):
@@ -196,7 +196,7 @@ class BiliApi:
             "access_key": self.u.access_key,
             "actionKey": "appkey",
             "appkey": Crypto.APPKEY,
-            "click_time": int(time.time()),
+            "click_time": 1,
             "room_id": room_id,
             "anchor_id": up_id,
         }


### PR DESCRIPTION
点赞API的`click_time`参数不是时间戳，是点赞连击次数，我之前抓包看过。用时间戳不太好，我想没有人能点那么多赞🤣