### PR TITLE
fix:GHProxy镜像源url被河蟹,替换新url

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ case ${MIRRORS} in
 "1")
     # https://ghproxy.com/
     echo -e "${Green} [INFO] 使用镜像源-GHProxy ${Plain}"
-    git remote set-url origin https://ghproxy.com/https://github.com/XiaoMiku01/fansMedalHelper.git
+    git remote set-url origin https://mirror.ghproxy.com/https://github.com/XiaoMiku01/fansMedalHelper.git
     ;;
 "2")
     # http://fastgit.org/


### PR DESCRIPTION
docker运行选择-e MIRRORS=1时的镜像源修改