### PR TITLE
feat: 利用白名单实现手动调整任务的执行优先级

### DIFF
--- a/src/user.py
+++ b/src/user.py
@@ -83,16 +83,28 @@ class BiliUser:
         """
         self.medals.clear()
         self.medalsNeedDo.clear()
-        async for medal in self.api.getFansMedalandRoomID():
-            if self.whiteList == [0]:
+        if self.whiteList == [0]:
+            self.log.info(f"启用黑名单，共 {len(self.bannedList)} 个粉丝牌")
+            async for medal in self.api.getFansMedalandRoomID():
                 if medal['medal']['target_id'] in self.bannedList:
-                    self.log.warning(f"{medal['anchor_info']['nick_name']} 在黑名单中，已过滤")
-                    continue
-                self.medals.append(medal) if medal['room_info']['room_id'] != 0 else ...
-            else:
-                if medal['medal']['target_id'] in self.whiteList:
+                    self.log.warning(
+                        f"[{medal['medal']['target_id']}] {medal['anchor_info']['nick_name']} 在黑名单中，已过滤")
+                else:
                     self.medals.append(medal) if medal['room_info']['room_id'] != 0 else ...
-                    self.log.success(f"{medal['anchor_info']['nick_name']} 在白名单中，加入任务")
+        else:
+            self.log.info(f"启用白名单，共 {len(self.whiteList)} 个粉丝牌")
+            medals = {}
+            async for medal in self.api.getFansMedalandRoomID():
+                if medal['medal']['target_id'] in self.whiteList:
+                    medals[medal['medal']['target_id']] = medal if medal['room_info']['room_id'] != 0 else ...
+            # 重新按白名单顺序调整排序
+            for targetId in self.whiteList:
+                if medals.get(targetId) is not None:
+                    self.medals.append(medals[targetId])
+                    self.log.success(
+                        f"[{medals[targetId]['medal']['target_id']}] {medals[targetId]['anchor_info']['nick_name']} 在白名单中，加入任务")
+                else:
+                    self.log.warning(f"[{targetId}] 对应的粉丝牌未找到，已跳过")
         [
             self.medalsNeedDo.append(medal)
             for medal in self.medals


### PR DESCRIPTION
因B站粉丝牌升级任务规则更新，新规则同一时间只允许在一个直播间挂机，该规则严重拉长了程序执行的总时长，当粉丝牌较多时，一天24小时可能无法完成所有粉丝牌的升级任务。

此次修改通过将需要执行任务的粉丝牌按照白名单输入的顺序重新排序，从而达到通过手动修改配置文件白名单即可调整任务执行优先级的目的。用户可将自己认为重要的粉丝牌放在白名单靠前的位置即可优先执行升级任务。

> 没必要吧 填了白名单后 所有的都会执行任务 顺序无所谓的

因为我牌子很多，而且经常手动跑，如果不能调整优先级，又想确保某些牌子的任务能完成，就得经常手动去改配置文件，先把高优先级的放白名单，等全部完成以后，再把低优先级的换进去，会非常麻烦。


_update: 之前PR的commit被我错误地提交到fork的master分支上了，而github又不能改PR来源端的分支，只能重新提一个PR，非常抱歉。_