### PR TITLE
增加日志输出到文件方便检查，统一日志格式及配置

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,26 @@ import aiohttp
 import itertools
 from src import BiliUser
 
+log_file = os.path.join(os.path.dirname(__file__), "log/fansMedalHelper_{time:YYYY-MM-DD}.log")
+log_format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
+
+logger.remove()
+logger.add(
+    sys.stdout,
+    format=log_format,
+    backtrace=True,
+    diagnose=True,
+    level="INFO"
+)
+logger.add(
+    log_file,
+    format=log_format,
+    backtrace=True,
+    diagnose=True,
+    rotation="00:00",
+    retention="30 days",
+    level="DEBUG"
+)
 log = logger.bind(user="B站粉丝牌助手")
 __VERSION__ = "0.3.8"
 

--- a/src/api.py
+++ b/src/api.py
@@ -121,6 +121,7 @@ class BiliApi:
         self.session = s
 
     def __check_response(self, resp: dict) -> dict:
+        logger.trace(resp)
         if resp["code"] != 0 or ("mode_info" in resp["data"] and resp["message"] != ""):
             raise BiliApiError(resp["code"], resp["message"])
         return resp["data"]

--- a/src/user.py
+++ b/src/user.py
@@ -8,16 +8,6 @@ from datetime import datetime, timedelta
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-logger.remove()
-logger.add(
-    sys.stdout,
-    colorize=True,
-    format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> <blue> {extra[user]} </blue> <level>{message}</level>",
-    backtrace=True,
-    diagnose=True,
-)
-
-
 class BiliUser:
     def __init__(self, access_token: str, whiteUIDs: str = '', bannedUIDs: str = '', config: dict = {}):
         from .api import BiliApi


### PR DESCRIPTION
- 日志按日期分割，方便检查具体运行记录或用于调试
- 日志只保留30天，不会产生过多无用日志