### PR TITLE
fix: 修复心跳跨日导致错误

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,6 +114,7 @@ async def main():
 
 def run(*args, **kwargs):
     loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.run_until_complete(main())
     log.info("任务结束，等待下一次执行。")
 
@@ -152,7 +153,5 @@ if __name__ == "__main__":
         scheduler.start()
     else:
         log.info("未配置定时器，开启单次任务。")
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+        run()
         log.info("任务结束")

--- a/src/api.py
+++ b/src/api.py
@@ -382,6 +382,8 @@ class BiliApi:
 
     async def heartbeat(self, room_id: int, up_id: int):
         url = "https://live-trace.bilibili.com/xlive/data-interface/v1/heartbeat/mobileHeartBeat"
+        today_timestamp = int(time.mktime(time.strptime(f"{time.strftime("%Y-%m-%d", time.localtime(time.time()))} 00:00:00", "%Y-%m-%d %H:%M:%S")))
+        timestamp = int(time.time())-60 if (int(time.time())-60) > today_timestamp else today_timestamp
         data = {
             "platform": "android",
             "uuid": self.u.uuids[0],
@@ -390,7 +392,7 @@ class BiliApi:
             "room_id": f"{room_id}",
             "parent_id": "6",
             "area_id": "283",
-            "timestamp": f"{int(time.time())-60}",
+            "timestamp": f"{timestamp}",
             "secret_key": "axoaadsffcazxksectbbb",
             "watch_time": "60",
             "up_id": f"{up_id}",


### PR DESCRIPTION
fix #205 
由于发送请求携带的60秒前的时间戳是位于之前一天导致的

### 需要注意
由于修复此问题后，当粉丝牌数量较多导致单次运行会超过一天/24小时后，不会在0点因报错而结束并推送。为避免影响后续运行，建议考虑额外增加指定时间停止的方案和参数，其中参数可考虑同时支持 `HH:mm:ss` 格式和 `秒` 格式
```ymal
STOPTIME: 00:00:00 # HH:mm:ss
# 或
STOPTIME: 86400 # 秒
```
思路大致如下，但我不熟asyncio，所以并没有去实现它
```python
stoptime = users.get("STOPTIME", None)
if stoptime:
    if stoptime.isdigit():
        delay = int(stoptime)
    else:
        delay = int(time.mktime(time.strptime(f'{time.strftime("%Y-%m-%d", time.localtime(time.time()))} {stoptime}', "%Y-%m-%d %H:%M:%S")))
        delay = delay if delay > time.time() else delay + 86400
```